### PR TITLE
EmployeeDaoのselectByIdメソッドを検索結果の保証（@Select(ensureResult = true)）に変更

### DIFF
--- a/employeeManagement/src/main/java/jp/co/flm/dao/EmployeeDao.java
+++ b/employeeManagement/src/main/java/jp/co/flm/dao/EmployeeDao.java
@@ -25,7 +25,9 @@ public interface EmployeeDao {
 	@Select
 	List<Employee> selectAll();
 	
-	@Select
+	//検索結果の保証
+	//該当がない場合org.seasar.doma.jdbc.ResultMappingExceptionがスローされる。
+	@Select(ensureResult = true)
 	Employee selectById(Integer employeeId);
 	
 	

--- a/employeeManagement/src/test/java/jp/co/flm/dao/EmployeeDaoTest02.java
+++ b/employeeManagement/src/test/java/jp/co/flm/dao/EmployeeDaoTest02.java
@@ -1,0 +1,57 @@
+package jp.co.flm.dao;
+
+//import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.seasar.doma.jdbc.NoResultException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import jp.co.flm.entity.Employee;
+
+/**
+ * @author FLM
+ * @version 1.0 yyyy/mm/dd
+ */
+@SpringBootTest
+@DisplayName("PT001_01:EmployeeDaoのテスト")
+public class EmployeeDaoTest02 {
+
+	@Autowired
+	EmployeeDao sut;
+
+	@Test
+	@DisplayName("PT001_01_001：メンバーが検索できる場合")
+	void testSelectById_test1() {
+		// setup
+		Integer testArg_employeeId = 922101;
+		Employee expected = new Employee();
+		expected.setEmployeeId(922101);
+		expected.setEmployeeName("鈴木　一郎");
+		expected.setSection("研修部");
+		expected.setPhone("7700-2257");
+
+		// assert
+		Employee actual = sut.selectById(testArg_employeeId);
+		assertThat(actual,is(expected));
+
+	}
+
+	@Test
+	@DisplayName("PT001_01_002：メンバーが検索できない場合")
+	void testSelectById_test2() {
+		// setup
+		Integer testArg_employeeId = 922109;
+
+		// assert
+		//Employee actual = sut.selectById(testArg_employeeId);
+		//assertThat(actual,nullValue());
+		assertThrows(NoResultException.class, () -> sut.selectById(testArg_employeeId));
+
+	}
+
+}


### PR DESCRIPTION
EmployeeDaoTest02でselectByIdメソッド呼出し時にorg.seasar.doma.jdbc.ResultMappingExceptionがスローされること検証する記述追加